### PR TITLE
Use TCP/IP instead of socket (as failsafe)

### DIFF
--- a/linux/garrysmod/lua/autorun/server/sourcebans_cfg.lua
+++ b/linux/garrysmod/lua/autorun/server/sourcebans_cfg.lua
@@ -3,7 +3,7 @@
 	~ Lexi ~
 --]]
 require("sourcebans")
-sourcebans.SetConfig("hostname", "localhost");       -- Database Hostname
+sourcebans.SetConfig("hostname", "127.0.0.1");       -- Database Hostname
 sourcebans.SetConfig("username", "username");            -- Database Login name
 sourcebans.SetConfig("password", "password");                -- Database Login Password
 sourcebans.SetConfig("database", "sourcebans");      -- Database 'database' or 'schema' selection


### PR DESCRIPTION
I had problems with sockets using a default mysql install on Ubuntu server. having 127.0.0.1 instead of localhost makes it use the normal connection instead of a socket.